### PR TITLE
FOLIO-3231 Remove old API lint and doc config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,6 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  publishAPI = 'no'
-  runLintRamlCop = 'no'
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
The settings were 'false' so not being used.
If needed in the future, then use api-lint and api-doc.

The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/
